### PR TITLE
Gadget Tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,15 @@ gadget_release: libgadget $(GADGET_SOURCES) $(VERSION_FILE) $(LIBGADGET_SOURCES)
 	@mkdir -p build/linux_arm64
 	@mkdir -p build/windows
 	@mkdir -p build/darwin
+	@echo "  Linux AMD64"
 	@GOOS=linux GOARCH=amd64 go build -o build/linux/gadget -ldflags="-s -w" -v ./gadgetcli
+	@echo "  Linux ARM"
 	@GOOS=linux GOARCH=arm go build -o build/linux_arm/gadget -ldflags="-s -w" -v ./gadgetcli
+	@echo "  Linux ARM64"
 	@GOOS=linux GOARCH=arm64 go build -o build/linux_arm64/gadget -ldflags="-s -w" -v ./gadgetcli
+	@echo "  Windows AMD64"
 	@GOOS=windows GOARCH=amd64 go build -o build/windows/gadget.exe -ldflags="-s -w" -v ./gadgetcli
+	@echo "  MacOS"
 	@GOOS=darwin GOARCH=amd64 go build -o build/darwin/gadget -ldflags="-s -w" -v ./gadgetcli
 
 gadgetosinit_release: libgadget $(GADGET_SOURCES) $(VERSION_FILE) $(LIBGADGET_SOURCES)

--- a/gadgetcli/main.go
+++ b/gadgetcli/main.go
@@ -51,6 +51,7 @@ var Commands = []GadgetCommand{
 	{Name: "shell", Function: GadgetShell, NeedsConfig: true},
 	{Name: "logs", Function: GadgetLogs, NeedsConfig: true},
 	{Name: "run", Function: GadgetRun, NeedsConfig: false},
+	{Name: "tag", Function: GadgetTag, NeedsConfig: true},
 	{Name: "version", Function: GadgetVersion, NeedsConfig: false},
 	{Name: "help", Function: GadgetHelp, NeedsConfig: false},
 }
@@ -94,6 +95,7 @@ func main() {
 		log.Info("  status      Fetch status of container[s]")
 		log.Info("  delete      Remove container[s] from gadget")
 		log.Info("  shell       Connect to remote device running GadgetOS")
+		log.Info("  tag         Tag built container[s] for config management")
 		log.Info("  logs        Fetch logs(stdout) of container[s]")
 		log.Info("  version     Print version information")
 		log.Info("  help        Print this message")

--- a/gadgetcli/tag.go
+++ b/gadgetcli/tag.go
@@ -1,0 +1,119 @@
+/*
+This file is part of the Gadget command-line tools.
+Copyright (C) 2017 Robert Wolterman.
+
+Gadget is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+Gadget is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Gadget.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/nextthingco/libgadget"
+	log "gopkg.in/sirupsen/logrus.v1"
+	"os/exec"
+)
+
+func tagUsage() error {
+	log.Info("Usage:  gadget [flags] tag [repository] [tag]     ")
+	log.Info("                *opt           *req      *opt     ")
+	log.Info("Value (repository): repository for        ")
+	log.Info("Value (rootfs): kernel <more to be added soon> ")
+
+	return errors.New("Incorrect edit usage")
+}
+
+// Process the build arguments and execute build
+func GadgetTag(args []string, g *libgadget.GadgetContext) error {
+
+	if len(args) < 1 {
+		return tagUsage()
+	}
+
+	// find docker binary in path
+	binary, err := exec.LookPath("docker")
+	if err != nil {
+		log.Error("Failed to find local docker binary")
+		log.Warn("Is docker installed?")
+
+		log.WithFields(log.Fields{
+			"function": "GadgetBuild",
+			"stage":    "LookPath(docker)",
+		}).Debug("Couldn't find docker in the $PATH")
+		return err
+	}
+
+	err = libgadget.EnsureDocker(binary, g)
+	if err != nil {
+		log.Errorf("Failed to contact the docker daemon.")
+		log.Warnf("Is it installed and running with appropriate permissions?")
+		return err
+	}
+
+	log.Info("Tagging:")
+
+	// We're going to tag all the containers in the config
+	stagedContainers := append(g.Config.Onboot, g.Config.Services...)
+
+	tagFailed := false
+
+	for _, container := range stagedContainers {
+        // Figure out the tag name
+        taggedImage := fmt.Sprintf("%s/%s", args[0], container.Name)
+        if len(args) > 1 {
+            taggedImage = fmt.Sprintf("%s/%s:%s", args[0], container.Name, args[1])
+        }
+
+        log.Infof("  '%s' ➡ '%s'", container.ImageAlias, taggedImage)
+
+		stdout, stderr, err := libgadget.RunLocalCommand(binary,
+			"", g,
+			"tag",
+			container.ImageAlias,
+			taggedImage)
+
+		log.WithFields(log.Fields{
+			"function": "GadgetTag",
+			"name":     container.Alias,
+			"stage":    "docker tag",
+		}).Debug(stdout)
+		log.WithFields(log.Fields{
+			"function": "GadgetTag",
+			"name":     container.Alias,
+			"stage":    "docker tag",
+		}).Debug(stderr)
+
+		if err != nil {
+
+			tagFailed = true
+
+			log.Errorf("Failed to tag '%s'", container.Name)
+
+			log.WithFields(log.Fields{
+				"function": "GadgetTag",
+				"name":     container.Name,
+			}).Debug("The tag command returned an error, possible sources are any docker failure scenario")
+
+		} else {
+			log.Info("    Done ✔")
+		}
+	}
+
+	if tagFailed {
+		err = errors.New("Failed to tag one or more containers")
+	}
+
+	return err
+}


### PR DESCRIPTION
Adding the following command to the gadgetcli workflow:

`gadget tag`

Will tag all images in a gadget.yml in one shot.