### PR TITLE
adding change to allow for both custom ip AND custom hostIp

### DIFF
--- a/libgadget/infra.go
+++ b/libgadget/infra.go
@@ -139,17 +139,25 @@ func RequiredSsh() error {
 	GadgetPrivKeyLocation = filepath.Join(sshLocation, "gadget_rsa")
 	GadgetPubKeyLocation = filepath.Join(sshLocation, "gadget_rsa.pub")
 
-	present := false
-	if ip, present = os.LookupEnv("GADGET_ADDR"); present == false {
+	ipPresent := false
+	if ip, ipPresent = os.LookupEnv("GADGET_ADDR"); ipPresent == false {
 		// check OS for IP address
 		if runtime.GOOS == "windows" {
 			ip = "192.168.82.1:22"
-			hostIp = "192.168.82.2"
 		} else {
 			ip = "192.168.81.1:22"
-			hostIp = "192.168.81.2"
 		}
 	}
+
+	hostIpPresent := false
+	if hostIp, hostIpPresent = os.LookupEnv("GADGET_HOST_ADDR"); hostIpPresent == false {
+		// check OS for IP address
+		if runtime.GOOS == "windows" {
+			hostIp = "192.168.82.2"
+		} else {
+			hostIp = "192.168.81.2"
+		}
+	}	
 
 	// check/create ~/.ssh
 	sshDirExists, err := PathExists(sshLocation)


### PR DESCRIPTION
Resolution for https://github.com/NextThingCo/gadgetcli/issues/6 by adding an additional optional env var in the case where your system issued IPs don't match Windows/non-Windows pattern in code.

Followed the same pattern for the hidden GADGET_ADDR; new env var is GADGET_HOST_ADDR and should be set to what's desired for the hostIp address.

Did not add any README changes, however, it would likely be helpful to add to the Troubleshooting section of https://docs.getchip.com/gadget.html.