### PR TITLE
Makefile: build date doesn't work on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION="0.0"
 GIT_COMMIT=$(shell git rev-parse --short HEAD)
 GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-BUILD_DATE=$(shell date --iso-8601)
+BUILD_DATE=$(shell date '+%Y-%m-%d')
 VERSION_FILE=libgadget/version.go
 
 ## This is an arbitrary comment to arbitrarily change the commit hash


### PR DESCRIPTION
OS X doesn't support the `--iso-8601` flag, causing the constants in `version.go` to be populated incorrectly.

```
$ date --iso-8601
date: illegal option -- -
usage: date [-jnRu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ... 
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]
```

My suggestion is to use the standard `date` formatting options, so the command would be: `date '+%Y-%m-%d'`.

OS X output:
```
$ date '+%Y-%m-%d'
2017-12-03
```

Linux output:
```
$ date '+%Y-%m-%d'
2017-12-03
```

Best.